### PR TITLE
Api tests

### DIFF
--- a/datapower_net.py
+++ b/datapower_net.py
@@ -18,6 +18,7 @@ class DataPowerNet():
     password = None
     use_kubeconfig = False
     items = {}
+    api_tests = None
 
     def __init__(self, config, trawler):
         # Takes in config object and trawler instance it's behind
@@ -28,6 +29,9 @@ class DataPowerNet():
         # Datapower username to use for REST calls
         self.username = config.get('username', 'admin')
         self.secret = config.get('secret', 'gateway-admin-secret')
+        api_test_config = config.get('api_tests', None)
+        if api_test_config and api_test_config['enabled'] == True:
+            self.api_tests = api_test_config['apis']
         # Load password from secret `datapower_password`
         try:
             self.password = trawler.read_secret('datapower_password')
@@ -91,12 +95,15 @@ class DataPowerNet():
                         namespace=i.metadata.namespace,
                         username=self.username,
                         password=password,
-                        trawler=self.trawler)
+                        trawler=self.trawler,
+                        api_tests=self.api_tests
+                        )
                 self.items[dp_key].gather_metrics()
                 logger.info("DataPowers in list: {}".format(len(pods)))
         except client.rest.ApiException as exception:
             logger.error("Error calling kubernetes API")
             logger.debug(exception)
+
 
 
 class DataPower():
@@ -110,9 +117,10 @@ class DataPower():
     statistics_enabled = False
     ip = '127.0.0.1'
     trawler = None
+    api_tests = None
     labels = {}
 
-    def __init__(self, ip, port, name, namespace, username, password, trawler):
+    def __init__(self, ip, port, name, namespace, username, password, trawler, api_tests=None):
         self.ip = ip
         self.port = port
         self.name = name
@@ -121,6 +129,7 @@ class DataPower():
         self.password = password
         self.get_info()
         self.trawler = trawler
+        self.api_tests = api_tests
         self.are_statistics_enabled()
         self.labels = {"namespace": self.namespace}
         logger.info('DataPower {} {} initialised at {}:{}'.format(self.name, self.v5c, self.ip, self.port))
@@ -194,6 +203,10 @@ class DataPower():
         # Needs statistics enabled:
         if self.statistics_enabled:
             self.fetch_data('HTTPTransactions2', 'http')
+        if self.api_tests:
+            for api in self.api_tests:
+                self.invoke_api(api)
+
 
     def fetch_data(self, provider, label, suffix=''):
         """ fetch data from a status provider """
@@ -296,6 +309,34 @@ class DataPower():
                                        pod_name=self.name, labels=labels)
                 self.trawler.set_gauge('datapower', "gateway_peering_primary_offset", entry["ReplicationOffset"], 
                                        pod_name=self.name, labels=labels)
+
+    def invoke_api(self, api):
+        http_call = getattr(requests, api['method']) 
+        result = http_call(
+            "https://{}:9443{}".format(self.ip, api['path']), 
+            headers=api.get('headers', None),
+            timeout=5,
+            verify=False,
+            allow_redirects=False
+        )
+        elapsed_time = result.elapsed.microseconds
+        size = len(result.text)
+        status = result.status_code
+        self.trawler.set_gauge(
+            'datapower',
+            "invoke_api_{}_size".format(api['name']),
+            size,
+            pod_name=self.name, labels=self.labels)
+        self.trawler.set_gauge(
+            'datapower',
+            "invoke_api_{}_status".format(api['name']),
+            status,
+            pod_name=self.name, labels=self.labels)
+        self.trawler.set_gauge(
+            'datapower',
+            "invoke_api_{}_time".format(api['name']),
+            elapsed_time,
+            pod_name=self.name, labels=self.labels)
 
 
 if __name__ == "__main__":

--- a/test_trawler.py
+++ b/test_trawler.py
@@ -236,6 +236,7 @@ def test_datapower_instance_connecttimeout(caplog, mocker):
         assert 'rest-mgmt' in caplog.text
 
 def test_datapower_instance_api_test(caplog, mocker):
+    """ Test per gateway api testing """
     caplog.set_level(logging.INFO)
     api_tests = [
         {"name":"test", "path": "/apitest", "method": "get"}
@@ -248,9 +249,17 @@ def test_datapower_instance_api_test(caplog, mocker):
         dp = datapower_net.DataPower('127.0.0.1', '5554', 'myDp', 'namespace', 'admin', 'password', boaty, api_tests)
         assert dp.name == 'myDp'
         assert dp.ip == '127.0.0.1'
+        assert dp.api_tests == api_tests
+        dp.invoke_api(dp.api_tests[0])
         assert prometheus_client.REGISTRY.get_sample_value(
             'datapower_invoke_api_test_size', 
             labels={"pod": "myDp", "namespace": "namespace"}) == 1
+        assert prometheus_client.REGISTRY.get_sample_value(
+            'datapower_invoke_api_test_time', 
+            labels={"pod": "myDp", "namespace": "namespace"})
+        assert prometheus_client.REGISTRY.get_sample_value(
+            'datapower_invoke_api_test_status_total', 
+            labels={"pod": "myDp", "namespace": "namespace", "code": "200"})
 
 def test_manager_fishing_error(mocker, caplog):
     caplog.set_level(logging.INFO)


### PR DESCRIPTION
New optional block within the datapower net config to test invokes of APIs:

    api_tests:
      enabled: true
      apis:
        - name: testapi
          path: /testpath
          method: get
          headers: {}

Will produce metrics for size, time and response code e.g.

datapower_invoke_api_testapi_size{namespace="apic-gw",pod="gateway-0"} 111.0
datapower_invoke_api_testapi_time{namespace="apic-gw",pod="gateway-0"} 475801.0
datapower_invoke_api_testapi_status_total{code="404",namespace="apic-gw",pod="gateway-0"} 1.0
datapower_invoke_api_testapi_status_total{code="200",namespace="apic-gw",pod="gateway-0"} 1.0
