### PR TITLE
Added MTLS support 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 'master'  # Use the sha / tag you want to point at
+    rev: '3.9.2'  # Use the sha / tag you want to point at
     hooks:
     -   id: flake8
         args: []

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,5 @@ pytest-mock
 pytest_catchlog
 requests-mock
 python-coveralls
+flask
+Werkzeug

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ pytest-cov
 pytest-mock
 requests-mock
 alchemy-logging>=1.0.3
+flask
+Werkzeug

--- a/trawler.py
+++ b/trawler.py
@@ -64,7 +64,7 @@ class Trawler(object):
                 context.verify_mode = ssl.CERT_REQUIRED
                 context.load_verify_locations(cert_path + 'ca.crt')
                 context.load_cert_chain(cert_path + 'tls.crt', cert_path + 'tls.key')
-                logger.info('Starting flask http port at http://0.0.0.0:{}'.format(port))
+                logger.info('Starting flask https port at http://0.0.0.0:{}'.format(port))
                 app.run('0.0.0.0', port, ssl_context=context)
             else:
                 port = self.config['prometheus'].get('port')

--- a/trawler.py
+++ b/trawler.py
@@ -38,13 +38,14 @@ class Trawler(object):
     use_kubeconfig = True
     # Default path for secrets in container build - override with envvar SECRETS
     mtls = False
+    # mtls defaults to false. can be set via the ENABLE_MTLS environment variable
     secrets_path = '/app/secrets'
     graphite = None
     gauges = {}
 
     def __init__(self, config_file=None, ):
         self.secrets_path = os.getenv('SECRETS', self.secrets_path)
-        self.mtls = os.getenv("HAS_MTLS_ENABLED", 'False').lower() in ('true', '1', 't')
+        self.mtls = os.getenv("ENABLE_MTLS", 'False').lower() in ('true', '1', 't')
         if config_file:
             self.load_config(config_file)
         if 'logging' in self.config:

--- a/trawler.py
+++ b/trawler.py
@@ -12,12 +12,10 @@ from datapower_net import DataPowerNet
 from manager_net import ManagerNet
 from analytics_net import AnalyticsNet
 from watch_pods import Watcher
-from prometheus_client import start_http_server
+from prometheus_client import start_http_server, Gauge, Counter, make_wsgi_app
 import metrics_graphite
-from prometheus_client import Gauge, Counter
 from flask import Flask
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
-from prometheus_client import make_wsgi_app
 import ssl
 
 
@@ -44,8 +42,9 @@ class Trawler(object):
     graphite = None
     gauges = {}
 
-    def __init__(self, config_file=None, mtls=False):
+    def __init__(self, config_file=None, ):
         self.secrets_path = os.getenv('SECRETS', self.secrets_path)
+        self.mtls = os.getenv('HAS_MTLS_ENABLED')
         if config_file:
             self.load_config(config_file)
         if 'logging' in self.config:
@@ -222,10 +221,9 @@ class Trawler(object):
               help="Specifies an alternative config file",
               default=None,
               type=click.Path())
-@click.option('--mtls', is_flag=True, envar='MTLS', help="Will enable mtls support.")
-def cli(config=None, mtls=False):
+def cli(config=None, ):
     """ run main trawler application """
-    trawler = Trawler(config, mtls)
+    trawler = Trawler(config)
     trawler.trawl_metrics()
 
 

--- a/trawler.py
+++ b/trawler.py
@@ -44,7 +44,7 @@ class Trawler(object):
 
     def __init__(self, config_file=None, ):
         self.secrets_path = os.getenv('SECRETS', self.secrets_path)
-        self.mtls = os.getenv('HAS_MTLS_ENABLED')
+        self.mtls = os.getenv("HAS_MTLS_ENABLED", 'False').lower() in ('true', '1', 't')
         if config_file:
             self.load_config(config_file)
         if 'logging' in self.config:


### PR DESCRIPTION
Added MTLS support to trawler by replacing prometheus start_http_client to a flask endpoint that exposes prometheus metrics. 
MTLS can be enabled using --mtls flag in while running trawler.py or can be enabled as an envar 
