### PR TITLE
fix(trawler.py): is_enabled check

### DIFF
--- a/trawler.py
+++ b/trawler.py
@@ -171,7 +171,7 @@ class Trawler(object):
     def is_enabled(self, net_name):
         """ is net in config and enabled """
         if net_name in self.config['nets']:
-            if self.config['nets']['certs'].get('enabled', True):
+            if self.config['nets'][net_name].get('enabled', True):
                 return True
         return False
 


### PR DESCRIPTION
is_enabled is currently only checking  'certs'. The intention was likely to drag the is_enabled check into a separate function. However, net_name should then be referenced 