### PR TITLE
fix: Make timeouts for DataPower customisable in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ logging:
 nets:
   datapower:
     enabled: true
+    timeout: 5 
     username: trawler-monitor
     namespace: apic-gateway
   product:

--- a/datapower_net.py
+++ b/datapower_net.py
@@ -125,7 +125,7 @@ class DataPower():
     api_tests = None
     labels = {}
 
-    def __init__(self, ip, port, name, namespace, username, password, trawler, timeout=1, api_tests=None):
+    def __init__(self, ip, port, name, namespace, username, password, trawler, api_tests=None, timeout=1):
         self.ip = ip
         self.port = port
         self.name = name

--- a/datapower_net.py
+++ b/datapower_net.py
@@ -256,7 +256,7 @@ class DataPower():
         except requests.exceptions.RequestException as e:
             logger.info("{}: {} (Check rest-mgmt is enabled and you have network connectivity)".format(provider, e.strerror))
 
-# https://127.0.0.1:5554/mgmt/status/apiconnect/ObjectStatus
+# https://127.0.0.1:5554/mgmt/status/apiconnect/ObjectInstanceCounts
     def object_counts(self):
         """ Count objects within datapower domain """
         logger.info("Processing status provider ObjectInstanceCounts")


### PR DESCRIPTION
Also move to use ObjectInstanceCounts to improve performance

https://github.com/IBM/apiconnect-trawler/issues/59