### PR TITLE
feat: re-instate support for username/password and log level

### DIFF
--- a/deployment/certificate.yaml
+++ b/deployment/certificate.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: trawler-certificate
+  namespace: apic
+spec:
+  dnsNames:
+    - trawler.apic.svc.cluster.local
+  duration: 17520h0m0s
+  # Update with your appropriate cert issuer
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: ingress-cluster-issuer
+  renewBefore: 720h0m0s
+  secretName: trawler-certificate
+  usages:
+    - digital signature
+    - key encipherment

--- a/deployment/clusterrole.yaml
+++ b/deployment/clusterrole.yaml
@@ -1,20 +1,28 @@
-kind: ClusterRole
+---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
   name: trawler
 rules:
-- apiGroups: [""]
-  resources: ["pods","services","secrets"]
-  verbs: ["get","list"]
-- apiGroups: ["management.apiconnect.ibm.com"]
-  resources: ["managementclusters"]
-  verbs: ["get","list"]
-- apiGroups: ["analytics.apiconnect.ibm.com"]
-  resources: ["analyticsclusters"]
-  verbs: ["get","list"]
-- apiGroups: ["gateway.apiconnect.ibm.com"]
-  resources: ["gatewayclusters"]
-  verbs: ["get","list"]
-- apiGroups: ["portal.apiconnect.ibm.com"]
-  resources: ["portalclusters"]
-  verbs: ["get","list"]
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - secrets
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - management.apiconnect.ibm.com
+      - portal.apiconnect.ibm.com
+      - gateway.apiconnect.ibm.com
+      - analytics.apiconnect.ibm.com
+    resources:
+      - managementclusters
+      - analyticsclusters
+      - portalclusters
+      - gatewayclusters
+    verbs:
+      - get
+      - list

--- a/deployment/config.yaml
+++ b/deployment/config.yaml
@@ -1,16 +1,30 @@
 # Example configuration file
 prometheus:
-  port: 63512 
+  port: 63512
   enabled: true
+logging:
+  level: info
 nets:
+  apiconnect:
+    enabled: true
+  analytics:
+    enabled: true
+    namespace: analytics-namespace
+  certificates:
+    enabled: true
+    frequency: 600        
   datapower:
     enabled: true
     username: admin
-    namespace: apic
+    namespace: gateway-namespace
+    api_tests:
+      enabled: false
+      apis:
+        - name: testapi
+          path: /porg/catalog/test
+          method: get
+          headers: {}
   manager:
     enabled: true
-    username: admin
-    namespace: apic
-  analytics:
-    enabled: true
-    namespace: apic
+    process_org_metrics: false
+    namespace: manager-apic

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -18,48 +18,74 @@ spec:
         prometheus.io/port: "63512"
         prometheus.io/scrape: "true"
     spec:
-      volumes:
-      - name: trawler-config
-        configMap:
-          name: trawler
-          optional: true
-      - name: trawler-secrets
-        secret:
-          secretName: trawler
-          optional: true
-      hostNetwork: false
-      dnsPolicy: ClusterFirstWithHostNet
-      serviceAccount: trawler
-      tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-      terminationGracePeriodSeconds: 5
       containers:
-      - name: trawler
-        image: ghcr.io/ibm/apiconnect-trawler/trawler:main
-        imagePullPolicy: Always
-        securityContext:
-          allowPrivilegeEscalation: false
-          privileged: false
-          runAsNonRoot: true
-          readOnlyRootFilesystem: false
-        ports:
-        - containerPort: 63512 
-          name: metrics
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 200m
-            memory: 128Mi
-          limits:
-            cpu: 500m
-            memory: 256Mi
-        readinessProbe:
-          exec:
-            command: [ "test", "-e", "/app/trawler.py" ]
-          initialDelaySeconds: 10
-        volumeMounts:
-        - mountPath: /app/config
+        - env:
+          - name: MGMT_CREDS
+            value: /app/management
+          - name: ANALYTICS_CERTS
+            value: /app/analytics
+          - name: SECURE
+            value: 'true'
+          - name: CERT_PATH
+            value: /app/certs
+          - name: CONFIG_PATH
+            value: /app/config/config.yaml
+          image: $IMAGE
+          imagePullPolicy: Always
+          name: trawler
+          ports:
+            - containerPort: 63512
+              name: metrics
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /app/config
+              name: trawler-config
+            - mountPath: /app/management
+              name: trawler-creds
+            - mountPath: /app/datapower
+              name: datapower-creds              
+# Update the following for your analytics deployment (replace analytics with your subsystem name)
+            - mountPath: /app/analytics
+              name: analytics-client-certificate
+              readOnly: true
+            - mountPath: /app/certs
+              name: trawler-certificate
+              readOnly: true
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: false
+      serviceAccount: trawler
+      terminationGracePeriodSeconds: 5
+      volumes:
+        - configMap:
+            name: trawler-config
+            optional: true
           name: trawler-config
-        - mountPath: /app/secrets
-          name: trawler-secrets
+        - name: trawler-creds
+          secret:
+            optional: true
+            secretName: trawler-mgmt-creds
+        - name: trawler-certificate
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: trawler-certificate
+        - name: analytics-client-certificate
+          secret:
+            defaultMode: 420
+            secretName: analytics-client
+        - name: datapower-creds
+          secret:
+            defaultMode: 420
+            optional: true
+            secretName: trawler-dp-creds

--- a/deployment/kustomization.yaml
+++ b/deployment/kustomization.yaml
@@ -1,18 +1,21 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 configMapGenerator:
-- name: trawler
+- name: trawler-config
   files:
   - config.yaml
 resources:
+- certificate.yaml
 - deployment.yaml
 - serviceaccount.yaml
 - clusterrole.yaml
 - clusterrolebinding.yaml
-# Uncomment secret.yaml if you have set passwords in it
-# - secret.yaml
+- networkpolicy_trawler-a7s.yaml
+- networkpolicy_trawler.yaml
+- secret-mgmt.yaml
+- secret-dp.yaml
 #  Uncomment the following if you are using prometheus-operator
 # - service.yaml
 # - servicemonitor.yaml
 
-namespace: apic-monitoring
+namespace: apic

--- a/deployment/networkpolicy_trawler-a7s.yaml
+++ b/deployment/networkpolicy_trawler-a7s.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: trawler-a7s
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: trawler
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: analytics
+      app.kubernetes.io/name: director
+  policyTypes:
+    - Ingress

--- a/deployment/networkpolicy_trawler.yaml
+++ b/deployment/networkpolicy_trawler.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: trawler-networkpolicy
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: openshift-user-workload-monitoring
+          podSelector: {}
+      ports:
+        - port: 63512
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: trawler
+  policyTypes:
+    - Ingress

--- a/deployment/secret-dp.yaml
+++ b/deployment/secret-dp.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+stringData:
+  username: admin
+  password: 
+kind: Secret
+metadata:
+  name: trawler-dp-creds
+type: Opaque

--- a/deployment/secret-mgmt.yaml
+++ b/deployment/secret-mgmt.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+stringData:
+  client_id: 
+  client_secret:
+# Uncomment and insert the values for the below as needed
+#  username: 
+#  password: 
+#  realm:
+kind: Secret
+metadata:
+  name: trawler-mgmt-creds
+type: Opaque

--- a/deployment/secret.yaml
+++ b/deployment/secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-data:
-# Uncomment and insert the base64 encoded values for the below as needed
-#  cloudmanager_password: 
-#  datapower_password: 
-kind: Secret
-metadata:
-  name: trawler
-type: Opaque

--- a/deployment/service.yaml
+++ b/deployment/service.yaml
@@ -8,7 +8,7 @@ metadata:
   name: trawler
 spec:
   ports:
-  - name: metrics
+  - name: web
     port: 63512
     protocol: TCP
     targetPort: 63512

--- a/deployment/servicemonitor.yaml
+++ b/deployment/servicemonitor.yaml
@@ -6,9 +6,24 @@ metadata:
   name: trawler
 spec:
   endpoints:
-  - port: metrics
+  - port: web
     path: /
-  jobLabel: trawler
+    interval: 30s
+    scheme: https
+    tlsConfig:
+      ca:
+        secret:
+          key: ca.crt
+          name: trawler-certificate
+      cert:
+        secret:
+          key: tls.crt
+          name: trawler-certificate
+      insecureSkipVerify: false
+      keySecret:
+        key: tls.key
+        name: trawler-certificate
+      serverName: trawler.apic.svc.cluster.local
   selector:
     matchLabels:
       app: trawler

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,15 +2,18 @@
 
 To install trawler, you can make use of the sample yaml files within the [deployment](../deployment) folder. You will need to customise these according to your deployment in the following ways:
 
- - Adjustments to `config.yaml`:
-     - Change namespace pointers to the appropriate namespace you have the API Connect components deployed in.
-     - Select which nets you want to enable.
-     - Set the usernames for datapower and cloud manager.
- - Adjustments to `kustomization.yaml`:
-     - Set the namespace you would like to deploy trawler into.
-     - Uncomment secret.yaml if you wish to include creation of secrets.
-     - Uncomment servicemonitor.yaml and service.yaml if you are using the prometheus operator model.
- - Set secrets for password values either through base64 encoded values in secret.yaml or through your usual method for managing secrets.
+- Adjustments to `config.yaml`:
+  - Change namespace pointers to the appropriate namespace you have the API Connect components deployed in.
+  - Select which nets you want to enable.
+- Adjustments to `secret-mgmt.yaml`
+  - Set the credentials to use for connecting to cloud manager.
+- Adjustments to `secret-dp.yaml`
+  - Set the credentials to use for connecting to datapower.
+- Adjustments to `kustomization.yaml`:
+  - Set the namespace you would like to deploy trawler into.
+  - Uncomment secret.yaml if you wish to include creation of secrets.
+  - Uncomment servicemonitor.yaml and service.yaml if you are using the prometheus operator model.
+- Set secrets for password values either through base64 encoded values in secret.yaml or through your usual method for managing secrets.
 
 These can either be imported to your cluster directly using `kubectl apply -k .` or to point to as a base for your own kustomize config and overlays with a kustomization.yaml which looks something like this: 
 
@@ -74,3 +77,14 @@ If you are using Instana you can configure the Instana agent to scrape metrics f
             customMetricSources:
             - url: '/'                       # metrics endpoint, the IP and port are auto-discovered
               metricNameIncludeRegex: '.*'   # regular expression to filter metrics 
+
+## Logging
+
+The logging channels are: trawler, apim, nets, apic, a7c, cert, dp
+
+You can set the default log by passing a command line options (`--log.default-level info`)  or in the config e.g. :
+
+```yaml
+logging:
+  level: info
+```

--- a/nets/main.go
+++ b/nets/main.go
@@ -184,12 +184,27 @@ func getNewToken(management_url string) (string, error) {
 	secretPath := os.Getenv(("MGMT_CREDS"))
 	clientId, _ := os.ReadFile(filepath.Clean(secretPath + "/client_id"))
 	clientSecret, _ := os.ReadFile(filepath.Clean(secretPath + "/client_secret"))
-
-	postBody, _ := json.Marshal(map[string]string{
-		"client_id":     string(clientId),
-		"client_secret": string(clientSecret),
-		"grant_type":    "client_credentials",
-	})
+	username, _ := os.ReadFile(filepath.Clean(secretPath + "/username"))
+	password, _ := os.ReadFile(filepath.Clean(secretPath + "/password"))
+	realm, _ := os.ReadFile(filepath.Clean(secretPath + "/realm"))
+	var postBody []byte
+	if (username != nil) && (password != nil) {
+		log.Log(alog.DEBUG, "Username and password are set")
+		postBody, _ = json.Marshal(map[string]string{
+			"client_id":     string(clientId),
+			"client_secret": string(clientSecret),
+			"username":      string(username),
+			"password":      string(password),
+			"realm":         string(realm),
+			"grant_type":    "password",
+		})
+	} else {
+		postBody, _ = json.Marshal(map[string]string{
+			"client_id":     string(clientId),
+			"client_secret": string(clientSecret),
+			"grant_type":    "client_credentials",
+		})
+	}
 	log.Log(alog.DEBUG, string(postBody))
 
 	tokenRequest := bytes.NewBuffer(postBody)


### PR DESCRIPTION
This will require a secret containing client_id, client_secret, username, password and realm

Also improving the docs and sample manifests for installation

For https://github.com/IBM/apiconnect-trawler/issues/109