### PR TITLE
chore(logger): Removes fmt print and uses alchemy logger

### DIFF
--- a/nets/apiconnect/apiconnect.go
+++ b/nets/apiconnect/apiconnect.go
@@ -39,7 +39,7 @@ var log = alog.UseChannel("apic")
 func (a *APIConnect) crdStatusMetrics(dynamicClient dynamic.DynamicClient, gvr schema.GroupVersionResource, crdStatus prometheus.GaugeVec) {
 	subsystems, err := dynamicClient.Resource(gvr).List(context.Background(), v1.ListOptions{})
 	if err != nil {
-		fmt.Printf("error getting subsystems: %v\n", err)
+		log.Log(alog.ERROR, "error getting subsystems %v", err)
 		return
 	}
 

--- a/nets/datapower/datapower.go
+++ b/nets/datapower/datapower.go
@@ -707,8 +707,7 @@ func (d *DataPower) invokeRestMgmt(ip string, path string) (*http.Response, erro
 	}
 	if response.StatusCode != 200 {
 		//return nil, errors.New(fmt.Sprintf("Unexpected status - Got %s, expected 200", response.Status))
-		fmt.Printf("ERROR %s\n", response.Status)
-		log.Log(alog.ERROR, response.Status)
+		log.Log(alog.ERROR, "Error invoking rest management with status %s", response.Status)
 		return nil, errors.New(response.Status)
 	}
 	return response, nil

--- a/nets/main.go
+++ b/nets/main.go
@@ -39,6 +39,10 @@ type BaseNet struct {
 	Frequency time.Duration
 }
 
+func (b *BaseNet) String() string {
+	return fmt.Sprintf("Base Net Name: %s || Base Net Disabled:  %t || Base net frequency: %d", b.Name, b.Disabled, b.Frequency)
+}
+
 type NetInterface interface {
 	Fish()
 }
@@ -52,9 +56,8 @@ var log = alog.UseChannel("nets")
 var dynamicClient *dynamic.DynamicClient
 
 func Enable(n BaseNet, frequency int) {
-	fmt.Println(n)
-	fmt.Println(frequency)
-	log.Log(alog.INFO, "enabling %s", n.Name)
+	log.Log(alog.INFO, "Enabling Base Net", n.String())
+
 	net_frequency := time.Duration(5)
 	if frequency != 0 {
 		log.Log(alog.INFO, "net is enabled at %ds frequency", frequency)

--- a/nets/main_test.go
+++ b/nets/main_test.go
@@ -1,13 +1,15 @@
 package nets
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/IBM/alchemy-logging/src/go/alog"
 	"github.com/stretchr/testify/assert"
 )
+
+var testLogger = alog.UseChannel("main_tests")
 
 func TestGetToken(t *testing.T) {
 	assert := assert.New(t)
@@ -21,8 +23,7 @@ func TestGetToken(t *testing.T) {
 
 	token, err := GetToken(server.URL)
 
-	fmt.Println(token)
+	testLogger.Log(alog.DEBUG, "fetched token: %s", token)
 	assert.Nil(err)
 	assert.Equal("123445", token)
-
 }

--- a/nets/manager/manager.go
+++ b/nets/manager/manager.go
@@ -160,6 +160,7 @@ func (m *Manager) getWebhookStats(management_url string, org string, catalog str
 		defer response.Body.Close()
 		var cgsResponse ConfiguredGatewayServices
 		err = json.NewDecoder(response.Body).Decode(&cgsResponse)
+		log.Log(alog.DEBUG, "Webhook status total results:", cgsResponse.TotalResults)
 		for _, cgs := range cgsResponse.Results {
 			m.metrics["outstandingSent"].WithLabelValues(org, catalog, cgs.Name, cgs.ServiceVersion).Set(float64(cgs.GatewayProcessingStatus.OutstandingSentEvents))
 			m.metrics["outstandingQueued"].WithLabelValues(org, catalog, cgs.Name, cgs.ServiceVersion).Set(float64(cgs.GatewayProcessingStatus.OutstandingQueuedEvents))

--- a/nets/manager/manager_test.go
+++ b/nets/manager/manager_test.go
@@ -2,18 +2,20 @@ package manager
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/IBM/alchemy-logging/src/go/alog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+var testLogger = alog.UseChannel("manager_tests")
 
 var m Manager
 
@@ -58,10 +60,11 @@ func TestTopologyValues(t *testing.T) {
 		Host: server.URL,
 	}
 	m := Manager{Config: config}
-	fmt.Println(m)
+
+	testLogger.Log(alog.DEBUG, "manager: %v", m)
 	assert.Equal(server.Config.Addr, "")
 	ti, err := m.getTopologyInfo(server.URL)
-	fmt.Println(ti)
+	testLogger.Log(alog.DEBUG, "cloud topology: %v", ti)
 	assert.Nil(err)
 	assert.Equal(float64(23), ti.Counts.ProviderOrgs)
 
@@ -82,12 +85,13 @@ func TestWebhookStats(t *testing.T) {
 		Host: server.URL,
 	}
 	m := Manager{Config: config}
-	fmt.Println(m)
+	testLogger.Log(alog.DEBUG, "manager: %v", m)
+
 	assert.Equal(server.Config.Addr, "")
 	m.getWebhookStats(server.URL, "org", "catalog")
 	assert.Empty("hllo")
 	//count := testutil.CollectAndCount(m.metrics["outstandingSent"], "manager_gateway_processing_outstanding_sent_events")
-	//fmt.Println(count)
+	//testLogger.Log(alog.DEBUG, "collected count: %v", count)
 	//assert.Equal(0, count)
 
 }
@@ -152,7 +156,7 @@ func TestFindAPIM(t *testing.T) {
 	getToken = MockGetToken
 	err := m.findAPIM()
 	if err != nil {
-		fmt.Println(err.Error())
+		t.Error("expected error to be nil but got %v", err)
 	}
 	assert.Empty(err)
 


### PR DESCRIPTION
## Description

Currently `fmt.Println` is used in place of alchemy logger.  This tries to use alchemy logger, in place of `fmt.Println`