### PR TITLE
Fixes warning in the code base

### DIFF
--- a/nets/manager/manager_test.go
+++ b/nets/manager/manager_test.go
@@ -2,7 +2,7 @@ package manager
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -137,7 +137,7 @@ func MockInvokeAPI(url string, certPath string, token string) (*http.Response, e
 		json = `{"cloud_id":"123445","cloud_name":"test-cloud","counts":{"provider_orgs":23}}`
 	}
 
-	body := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+	body := io.NopCloser(bytes.NewReader([]byte(json)))
 	r := http.Response{
 		StatusCode: 200,
 		Body:       body,

--- a/nets/manager/manager_test.go
+++ b/nets/manager/manager_test.go
@@ -155,9 +155,6 @@ func TestFindAPIM(t *testing.T) {
 	invokeAPI = MockInvokeAPI
 	getToken = MockGetToken
 	err := m.findAPIM()
-	if err != nil {
-		t.Error("expected error to be nil but got %v", err)
-	}
 	assert.Empty(err)
 
 	assert.Empty("full")


### PR DESCRIPTION
## Description

- Removes unnecessary error assertion
- Removes usage of `io/ioutil`, as its deprecated, starts using NopCloser from `os` package.

Reference 

- https://pkg.go.dev/io/ioutil
```
Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.
```