### PR TITLE
fix(config): remove config flag

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -34,4 +34,4 @@ USER 1001:0
 EXPOSE 63512
 ENV CONFIG_PATH=/app/config/config.yaml
 
-CMD ["/app/trawler", "-c", "/app/config/config.yaml"]
+CMD ["/app/trawler"]


### PR DESCRIPTION
### Overview:

- Removes the `-c /app/config/config.yaml` argument from the `Containerfile` `CMD`
- Fixes the following error on startup:

```
2025/09/16 17:56:13 [trawl:INFO] Loading config from config/config.yaml
flag provided but not defined: -c
Usage of /app/trawler:
  -log.chan-header-len int
    	Maximum length for log channel strings in the header (default 5)
  -log.default-level string
    	Default log level (default "info")
  -log.filters string
    	Per-channel log level configuration
  -log.function-signature
    	Log the full function signature for trace logging
  -log.goroutine-id
    	Log the numerica ID of the goroutine in the header
  -log.no-indent
    	Disable indentation
  -log.output-json
    	Output log lines as structured JSON rather than plain text
  -log.service-name string
    	Set a service name to display with each log line
```